### PR TITLE
CI Infrastructure Update to `v3`                           

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@main
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v3
     with:
       model: ${{ vars.NAME }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - closed
     branches:
       - main
+      - dev
       - backport/*.*
     paths:
       - config/**
@@ -21,7 +22,20 @@ jobs:
   pr-ci:
     name: CI
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v3
+    with:
+      model: ${{ vars.NAME }}
+      # root-sbd: if different from vars.NAME
+    permissions:
+      pull-requests: write
+      contents: write
+      statuses: write
+    secrets: inherit
+
+  pr-comment:
+    name: Comment
+    if: github.event_name == 'issue_comment'
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v3
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -30,21 +44,10 @@ jobs:
       contents: write
     secrets: inherit
 
-  pr-comment:
-    name: Comment
-    if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@main
-    with:
-      model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
-    permissions:
-      pull-requests: write
-      contents: write
-
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v3
     with:
       model: ${{ vars.NAME }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: >-
+      (github.event_name == 'pull_request' && github.event.action != 'closed') ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
     uses: access-nri/build-cd/.github/workflows/ci.yml@v3
     with:
       model: ${{ vars.NAME }}


### PR DESCRIPTION
This PR updates the infrastructure to `v3`, which includes a fix to the `!bump [major|minor]` command.
It also allows Prereleases for branches into `dev`.

> [!NOTE]
> Existing CI will still work. Rebase your existing PRs if these features are of interest to you. 

References ACCESS-NRI/build-cd#109
References ACCESS-NRI/build-cd#193
