### PR TITLE
Update to use um model vn14p5-rns

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.000",
+    "spack-packages": "2025.07.006",
     "spack-config": "2025.08.000"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -2,5 +2,5 @@
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
     "spack": "0.22",
     "spack-packages": "2025.07.006",
-    "spack-config": "2025.07.001"
+    "spack-config": "2025.08.000"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.08.09",
-    "spack-config": "2024.07.05"
+    "spack-packages": "2025.07.006",
+    "spack-config": "2025.07.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.07.006",
+    "spack-packages": "2025.08.000",
     "spack-config": "2025.08.000"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -33,7 +33,7 @@ spack:
 
     gcom:
       require:
-        - '@7.8'
+        - '@8.3'
 
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,8 @@ spack:
     # Direct dependencies
     um:
       require:
-        - '@13.0'
+        - '@13.5'
+        - model="vn13p5-rns"
 
     # Indirect dependencies
     eccodes:
@@ -36,7 +37,7 @@ spack:
 
     openmpi:
       require:
-        - '@4.1.5'
+        - '@4.1.7'
 
     # Specifications that apply to all packages
     all:

--- a/spack.yaml
+++ b/spack.yaml
@@ -49,6 +49,7 @@ spack:
         include:
           - access-ram3
           - openmpi
+          - gcom
           - um
         all:
           conflict:

--- a/spack.yaml
+++ b/spack.yaml
@@ -51,17 +51,12 @@ spack:
     unify: true
   modules:
     default:
-      enable:
-        - tcl
-      roots:
-        tcl: $spack/../release/modules
-        lmod: $spack/../release/lmod
       tcl:
         hash_length: 0
         include:
           - access-ram3
+          - openmpi
           - um
-        exclude_implicits: true
         all:
           autoload: direct
           conflict:
@@ -70,9 +65,8 @@ spack:
             set:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
-          all: '{name}/{version}'
           access-ram3: '{name}/2024.08.0'
-          um: '{name}/13.5'
+          um: '{name}/13.5-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -46,13 +46,11 @@ spack:
   modules:
     default:
       tcl:
-        hash_length: 0
         include:
           - access-ram3
           - openmpi
           - um
         all:
-          autoload: direct
           conflict:
             - '{name}'
           environment:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,6 +17,7 @@ spack:
     eccodes:
       require:
         - '@2.34.0'
+        - '+memfs'
     netcdf-c:
       require:
         - '@4.9.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-ram3@git.2024.08.0
+    - access-ram3@git.2025.08.000=null
   packages:
     # Direct dependencies
     um:
@@ -13,34 +13,27 @@ spack:
         - model="vn13p5-rns"
         - ~DR_HOOK
         - +eccodes
-
     # Indirect dependencies
     eccodes:
       require:
-         - '@2.34.0'
-
+        - '@2.34.0'
     netcdf-c:
       require:
         - '@4.9.2'
-
     netcdf-fortran:
       require:
         - '@4.5.2'
-
     fcm:
       require:
         - '@2021.05.0'
         # TODO: Generalize this Gadi-specific variant for spack.yaml
         - 'site=nci-gadi'
-
     gcom:
       require:
         - '@8.3'
-
     openmpi:
       require:
         - '@4.1.7'
-
     # Specifications that apply to all packages
     all:
       require:
@@ -65,11 +58,11 @@ spack:
             set:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
-          access-ram3: '{name}/2024.08.0'
+          access-ram3: '{name}/2025.08.000'
           um: '{name}/13.5-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release
     source_cache: $spack/../restricted/ukmo/source_cache
     build_stage:
-    - $TMPDIR/restricted/spack-stage
+      - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-ram3@git.2025.08.000=null
+    - access-ram3@git.2025.08.000
   packages:
     # Direct dependencies
     um:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,6 +11,7 @@ spack:
       require:
         - '@13.5'
         - model="vn13p5-rns"
+        - +eccodes
 
     # Indirect dependencies
     eccodes:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,6 +11,7 @@ spack:
       require:
         - '@13.5'
         - model="vn13p5-rns"
+        - ~DR_HOOK
         - +eccodes
 
     # Indirect dependencies
@@ -43,7 +44,7 @@ spack:
     # Specifications that apply to all packages
     all:
       require:
-        - '%intel@19.0.3.199'
+        - '%intel@2021.10.0'
         - target=x86_64_v4
   view: true
   concretizer:
@@ -71,7 +72,7 @@ spack:
         projections:
           all: '{name}/{version}'
           access-ram3: '{name}/2024.08.0'
-          um: '{name}/13.0'
+          um: '{name}/13.5'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release


### PR DESCRIPTION
Closes #13 

---
:rocket: The latest prerelease `access-ram3/pr14-14` at 1ebb538238cf50c98200b71311c0f9e29375e771 is here: https://github.com/ACCESS-NRI/ACCESS-rAM3/pull/14#issuecomment-3181393103 :rocket:















