### PR TITLE
[no ci] Add back setting SPACK_{name}_ROOT, removed in error in #16

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -43,6 +43,13 @@ spack:
   view: true
   concretizer:
     unify: true
+  modules:
+    default:
+      tcl:
+        all:
+          environment:
+            set:
+              'SPACK_{name}_ROOT': '{prefix}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,6 +44,7 @@ spack:
   concretizer:
     unify: true
   modules:
+    # NOTE: Don't remove! This section is mandatory for the rAM3 suite to work correctly.
     default:
       tcl:
         all:


### PR DESCRIPTION
References #16

## Background

When doing the `v6` infrastructure update for this repository, I'd mistakenly removed the `modules.default.tcl.all.environment.set.SPACK_{name}_ROOT` section, which is important in this repository. 

## The PR

* Add back the section!

## Testing

A release spack.yaml with the added section will look like: https://github.com/ACCESS-NRI/ACCESS-rAM3/actions/runs/17997324204/job/51199278964?pr=18#step:11:22

A prerelease spack.yaml with the added section will look like: https://github.com/ACCESS-NRI/ACCESS-rAM3/actions/runs/17997324204/job/51199278964?pr=18#step:12:21
