### PR TITLE
Infra Update `v8`: `spack v1` Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,12 +8,11 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.issue.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -23,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -33,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,12 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: >-
-      github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    if: github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
-      pr: ${{ github.event.pull_request.number }}
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
-
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -38,7 +34,5 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
-    with:
-      root-sbd: ${{ vars.NAME }}
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     secrets: inherit

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,8 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "2025.07.006"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.1",
+  "access-spack-packages": "2026.02.004",
+  "custom-scopes": [
+    "ukmo-restricted-scope"
+  ]
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,43 +3,56 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [access-ram3]
+  - _version: [2025.08.000]
   specs:
-    - access-ram3@git.2025.08.000
+  - access-ram3
   packages:
     # Direct dependencies
     um:
       require:
-        - '@13.5'
-        - model="vn13p5-rns"
-        - ~DR_HOOK
-        - +eccodes
+      - '@13.5'
+      - model="vn13p5-rns"
+      - ~DR_HOOK
+      - +eccodes
     # Indirect dependencies
     eccodes:
       require:
-        - '@2.34.0'
-        - '+memfs'
+      - '@2.34.0'
+      - '+memfs'
     netcdf-c:
       require:
-        - '@4.9.2'
+      - '@4.9.2'
     netcdf-fortran:
       require:
-        - '@4.5.2'
+      - '@4.5.2'
     fcm:
       require:
-        - '@2021.05.0'
-        # TODO: Generalize this Gadi-specific variant for spack.yaml
-        - 'site=nci-gadi'
+      - '@2021.05.0'
+      # TODO: Generalize this Gadi-specific variant for spack.yaml
+      - 'site=nci-gadi'
     gcom:
       require:
-        - '@8.3'
+      - '@8.3'
     openmpi:
       require:
-        - '@4.1.7'
+      - '@4.1.7'
+    # Compilers
+    c:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
+    cxx:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
+    fortran:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
     # Specifications that apply to all packages
     all:
-      require:
-        - '%intel@2021.10.0'
-        - target=x86_64_v4
+      prefer:
+      - target=x86_64_v4
   view: true
   concretizer:
     unify: true
@@ -51,9 +64,3 @@ spack:
           environment:
             set:
               'SPACK_{name}_ROOT': '{prefix}'
-  config:
-    install_tree:
-      root: $spack/../restricted/ukmo/release
-    source_cache: $spack/../restricted/ukmo/source_cache
-    build_stage:
-      - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,9 +25,13 @@ spack:
     netcdf-c:
       require:
       - '@4.9.2'
+      - '+shared'
     netcdf-fortran:
       require:
       - '@4.5.2'
+    hdf5:
+      require:
+      - '+shared'
     fcm:
       require:
       - '@2021.05.0'
@@ -36,9 +40,16 @@ spack:
     gcom:
       require:
       - '@8.3'
+      - '+mpi'
+    jasper:
+      require:
+      - '~opengl'
     openmpi:
       require:
       - '@4.1.7'
+    python:
+      require:
+      - '@3.11.7'
     # Compilers
     c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -31,6 +31,7 @@ spack:
       - '@4.5.2'
     hdf5:
       require:
+      - '@1.14.3'
       - '+shared'
     fcm:
       require:
@@ -43,6 +44,7 @@ spack:
       - '+mpi'
     jasper:
       require:
+      - '@4.2.8'
       - '~opengl'
     openmpi:
       require:


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#313 and PR ACCESS-NRI/build-cd#326
References rollout issue ACCESS-NRI/build-cd#328
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for deployments to `spack < 1.0`.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-cd < v8`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-cd >= v8`.

## Background

We are moving on up to `spack v1`! This update to spack contains many bug fixes, optimisations and new features that can be incorporated into `build-cd`.

This update also contains changes that make `spack v0.X` incompatible with this `build-cd v8` update - the most prominent one being the splitting of spacks core codebase from it's builtin spack-packages repo. This means that for provenance, one to keep track of both `builtin` spack-packages and our own, renamed `access-spack-packages`. `build-cd` will centrally control the version of builtin `spack-packages` for a given instance, and `config/versions.json`s `spack-packages` key is renamed to `access-spack-packages`.

As noted earlier, this major version of `build-cd` can only support `spack v1`, due to `spack v1`-specific commands in the infrastructure. If you still want to deploy to `spack v0.X`, you will need to change `build-cd` to `v7`, and update the `config/versions.json` file/`spack.yaml`.

## Features

* **Support for spack v1**: We're moving to a new, non-beta version of spack! It contains bug fixes, features and optimisations over the old version.

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Update `config/versions.json` with new inputs (also this PR!)
- [x] Validate compiler additions to the spack manifest (this PR, too!)
- [x] Test and Verify Model built with `spack v1`


---
:rocket: The latest prerelease `access-ram3/pr24-6` at 7c0a7c825cfdc094f6bbe2bc89fcdf02c0171075 is here: https://github.com/ACCESS-NRI/ACCESS-rAM3/pull/24#issuecomment-4513765250 :rocket:







