### PR TITLE
Fix issues with spack install on infra-update-v8

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -25,9 +25,13 @@ spack:
     netcdf-c:
       require:
       - '@4.9.2'
+      - '+shared'
     netcdf-fortran:
       require:
       - '@4.5.2'
+    hdf5:
+      require:
+      - '+shared'
     fcm:
       require:
       - '@2021.05.0'
@@ -36,9 +40,16 @@ spack:
     gcom:
       require:
       - '@8.3'
+      - '+mpi'
+    jasper:
+      require:
+      - '~opengl'
     openmpi:
       require:
       - '@4.1.7'
+    python:
+      require:
+      - '@3.11.7'
     # Compilers
     c:
       require:


### PR DESCRIPTION
Closes #28 

Tested on Gadi:

```
==> Installing access-ram3-latest-xckkfkc6khfe4lu6yllwtfnn5pchehge [24/24]
==> No patches needed for access-ram3
==> access-ram3: Executing phase: 'install'
==> access-ram3: Successfully installed access-ram3-latest-xckkfkc6khfe4lu6yllwtfnn5pchehge
  Stage: 0.00s.  Install: 0.00s.  Post-install: 0.16s.  Total: 1.03s
[+] /g/data/tm70/pcl851/spack/1.1/release/linux-x86_64_v4/access-ram3-latest-xckkfkc6khfe4lu6yllwtfnn5pchehge
==> Updating view at /g/data/tm70/pcl851/spack/1.1/environments/access-ram3/.spack-env/view
```