### PR TITLE
Update access-spack-packages version to a commit hash

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.004",
+  "access-spack-packages": "361fcf71d75c5c547e3f32332123598b0168b199",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-ram3]
-  - _version: [2025.08.000]
+  - _version: [2026.07.000]
   specs:
   - access-ram3
   packages:


### PR DESCRIPTION
Ensure build still works.

---
:rocket: The latest prerelease `access-ram3/pr36-3` at 1f77d8cb4e5abda17d178188b7c59fee51dbb7c4 is here: https://github.com/ACCESS-NRI/ACCESS-rAM3/pull/36#issuecomment-5125123827 :rocket:


