### PR TITLE
Remove specific version requirement for gcom

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -40,7 +40,6 @@ spack:
       - 'site=nci-gadi'
     gcom:
       require:
-      - '@8.3'
       - '+mpi'
     jasper:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-ram3]
-  - _version: [2025.08.000]
+  - _version: [2026.07.000]
   specs:
   - access-ram3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -40,6 +40,7 @@ spack:
       - 'site=nci-gadi'
     gcom:
       require:
+      - '@8'
       - '+mpi'
     jasper:
       require:


### PR DESCRIPTION
The spack-package specifies the required GCOM version quite precisely- there's no reason to specify it here. It does make the build fail when asking for um@13.8, since that explicitly specifies GCOM@8.4. There's no change for um@13.5.

---
:rocket: The latest prerelease `access-ram3/pr37-1` at 88d274ffb7ef6dabb95a049293371f78b64ab547 is here: https://github.com/ACCESS-NRI/ACCESS-rAM3/pull/37#issuecomment-5114559583 :rocket:


