### PR TITLE
Up spack-packages

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.004",
+  "access-spack-packages": "0d518ac39242041f09f554eccb9aa0e5c5547422",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-ram3]
-  - _version: [2025.08.000]
+  - _version: [2025.8.001]
   specs:
   - access-ram3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-ram3]
-  - _version: [2025.8.001]
+  - _version: [2025.08.001]
   specs:
   - access-ram3
   packages:


### PR DESCRIPTION
Tests new spack packages which set the default value of the variants to "default".

---
:rocket: The latest prerelease `access-ram3/pr38-3` at dec0893d83e4056add63906c7c831e4316ddf05e is here: https://github.com/ACCESS-NRI/ACCESS-rAM3/pull/38#issuecomment-5140018595 :rocket:



