### PR TITLE
Up to 13.8

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -23,6 +23,9 @@ spack:
       - model="vn13p5-rns"
       - ~DR_HOOK
       - +eccodes
+      - um_sources=""
+      - casim_sources=""
+      
     # Indirect dependencies
     eccodes:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,11 +20,15 @@ spack:
     um:
       require:
       - '@13.8'
-      - model="vn13p5-rns"
+      - model="vn13p8-am"
       - ~DR_HOOK
       - +eccodes
-      - um_sources=""
-      - casim_sources=""
+      - um_ref="UKMO_vn13.8"
+      - jules_ref="JULES_vn7.8"
+      - casim_ref="um13.8"
+      - shumlib_ref="um13.8"
+      - socrates_ref="um13.8"
+      - ukca_ref="um13.8"
       
     # Indirect dependencies
     eccodes:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
     # Direct dependencies
     um:
       require:
-      - '@13.5'
+      - '@13.8'
       - model="vn13p5-rns"
       - ~DR_HOOK
       - +eccodes
@@ -44,10 +44,6 @@ spack:
       - '@2021.05.0'
       # TODO: Generalize this Gadi-specific variant for spack.yaml
       - 'site=nci-gadi'
-    gcom:
-      require:
-      - '@8.3'
-      - '+mpi'
     jasper:
       require:
       - '@4.2.8'


### PR DESCRIPTION
Try to build the 13.8 executable

---
:rocket: The latest prerelease `access-ram3/pr42-3` at dea0d80915d45e13c28f47645b549c5896f602ad is here: https://github.com/ACCESS-NRI/ACCESS-rAM3/pull/42#issuecomment-5250170399 :rocket:


