### PR TITLE
Change default name of variants

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -86,5 +86,5 @@ spack:
   repos:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
-      commit: 0d518ac39242041f09f554eccb9aa0e5c5547422
+      commit: aa5f3481633a8774889fde9afed97fc6b82ec369
       destination: $env/package-repos/access-spack-packages

--- a/spack.yaml
+++ b/spack.yaml
@@ -86,5 +86,5 @@ spack:
   repos:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
-      tag: 2026.02.004
+      commit: 0d518ac39242041f09f554eccb9aa0e5c5547422
       destination: $env/package-repos/access-spack-packages


### PR DESCRIPTION
Cosmetic update of the spack packages, to make the concretization more informative.

---
:rocket: The latest prerelease `access-ram3/pr43-2` at 93f5265130caf8ca68a20f9982c2d14791bb395d is here: https://github.com/ACCESS-NRI/ACCESS-rAM3/pull/43#issuecomment-5249892190 :rocket:

